### PR TITLE
fix(api)!: Renaming classes and creating a default package object

### DIFF
--- a/pyconfigparser.py
+++ b/pyconfigparser.py
@@ -41,7 +41,7 @@ class Config:
         return self.__dict__.values()
 
 
-class Configparser:
+class ConfigParser:
     def __init__(self):
         self.__instance = None
         self.__hold_an_instance = True
@@ -145,4 +145,4 @@ class Configparser:
         return variable
 
 
-configparser = Configparser()
+configparser = ConfigParser()


### PR DESCRIPTION
BREAKING CHANGE: A class which provides the ConfigValue Object was not a good deal
Now there's a default package object called configparser which gives a Config(old ConfigValue) object