### PR TITLE
fix: change python version in pipeline tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Due to python compatibility changes, tests in the pipeline with previous versions were breaking.

This PR removes broken versions and adds more current versions.

NOTE: This PR assumes the breaking of compatibility with the removed versions.