### PR TITLE
fix: Fix incorrect interpreting strings with $ as env vars

### DIFF
--- a/pyconfigparser.py
+++ b/pyconfigparser.py
@@ -97,7 +97,7 @@ def _extract_env_variable_key(variable):
     return variable
 
 
-_VARIABLE_PATTERN = r'\$([a-zA-Z][\w]+|\{[a-zA-Z][\w]+\})$'
+_VARIABLE_PATTERN = r'^\$([a-zA-Z][\w]+|\{[a-zA-Z][\w]+\})$'
 _DEFAULT_CONFIG_FILES = ('config.json', 'config.yaml', 'config.yml')
 _ENTITY_NAME_PATTERN = r'^[a-zA-Z][\w]+$'
 _SUPPORTED_EXTENSIONS = {

--- a/test_configparser.py
+++ b/test_configparser.py
@@ -1,4 +1,4 @@
-from pyconfigparser import ConfigParser, ConfigError, ConfigFileNotFoundError,_is_variable
+from pyconfigparser import ConfigParser, ConfigError, ConfigFileNotFoundError, _is_variable
 from config.schemas import SIMPLE_SCHEMA_CONFIG, UNSUPPORTED_OBJECT_KEYS_SCHEMA
 import unittest
 import os


### PR DESCRIPTION
I noticed this bug where any string with a dollar sign `$` is being treated as env var and then fails when trying to load such env var. Saw the problem is the regex is missing an anchor at start `ˆ`. Adding this will make sure value needs to start with `$` and not randomly in middle of string.

Example of failure:

```yaml
MY_PW: <L/f\U<Uj2{.S95@^$Rx
```

When trying to load with config parser:
```shell
Error reading configuration file: Environment variable <L/f\U<Uj2{.S95@^$Rx was not found
```

I've added unit tests to cover this scenario

```shell
diosil1@root python-config-parser % python test_configparser.py 
............
----------------------------------------------------------------------
Ran 12 tests in 0.002s

OK
```

@BrunoSilvaAndrade please review this?