### PR TITLE
fix: incorrect matching env var strings with dollar sign

### DIFF
--- a/pyconfigparser.py
+++ b/pyconfigparser.py
@@ -97,7 +97,7 @@ def _extract_env_variable_key(variable):
     return variable
 
 
-_VARIABLE_PATTERN = r'\$([a-zA-Z][\w]+|\{[a-zA-Z][\w]+\})$'
+_VARIABLE_PATTERN = r'^\$([a-zA-Z][\w]+|\{[a-zA-Z][\w]+\})$'
 _DEFAULT_CONFIG_FILES = ('config.json', 'config.yaml', 'config.yml')
 _ENTITY_NAME_PATTERN = r'^[a-zA-Z][\w]+$'
 _SUPPORTED_EXTENSIONS = {

--- a/test_configparser.py
+++ b/test_configparser.py
@@ -1,4 +1,4 @@
-from pyconfigparser import ConfigParser, ConfigError, ConfigFileNotFoundError,_is_variable
+from pyconfigparser import ConfigParser, ConfigError, ConfigFileNotFoundError, _is_variable
 from config.schemas import SIMPLE_SCHEMA_CONFIG, UNSUPPORTED_OBJECT_KEYS_SCHEMA
 import unittest
 import os


### PR DESCRIPTION
As pointed out by @diogo, using $ as a variable value was causing an error during interpolation.

This merge fixes the issue.